### PR TITLE
allow users to set db_uri

### DIFF
--- a/src/bridge.py
+++ b/src/bridge.py
@@ -75,8 +75,16 @@ def run_bridge():  # pylint: disable=too-many-statements
 
     logger.info(f'Starting with ETH address {signer.address}')
 
-    with database(db=cfg['db_name'], host=cfg['db_host'],
-                  password=cfg['db_password'], username=cfg['db_username']):
+    if 'db_uri' in cfg:
+        uri = cfg['db_uri']
+    else:
+        db = cfg.get('db_name', 'test_db')
+        host = cfg.get('db_host', 'localhost')
+        password = cfg['db_password']
+        username = cfg['db_username']
+        uri = f"mongodb+srv://{username}:{password}@{host}/{db}?retryWrites=true&w=majority"
+
+    with database(uri):
 
         eth_wallet = MultisigWallet(w3, cfg['multisig_wallet_address'])
 

--- a/src/db/setup.py
+++ b/src/db/setup.py
@@ -4,13 +4,11 @@ import mongoengine
 
 
 @contextmanager
-def database(db="test_db", host='localhost', username=None, password=None):
+def database(uri):
     # alias = f"{db}-{host}-{username}"
 
-    DB_URI = f"mongodb+srv://{username}:{password}@{host}/{db}?retryWrites=true&w=majority"
-
     yield mongoengine.connect(
-        host=DB_URI
+        host=uri
     )
 
     mongoengine.disconnect()


### PR DESCRIPTION
This is useful when connecting to mongodb instances that
do not use the dns seed list connection format.
ie use 'mongodb://' protocol instead of 'mongodb+srv://'

see: https://docs.mongodb.com/manual/reference/connection-string/